### PR TITLE
Initial StuckKeyFix implementation

### DIFF
--- a/guest-agent/VfioService/VfioService/ClientManager.cs
+++ b/guest-agent/VfioService/VfioService/ClientManager.cs
@@ -44,6 +44,9 @@ namespace VfioService
                             }
                         }
                         break;
+                    case CommandIn.ReleaseModifiers:
+                        StuckKeyFix.ReleaseModifiers();
+                        break;
                     }
                 }
             }).Start();

--- a/guest-agent/VfioService/VfioService/Command.cs
+++ b/guest-agent/VfioService/VfioService/Command.cs
@@ -20,5 +20,6 @@ namespace VfioService
     {
         Ping = 0x01,
         RegisterHotKey = 0x02,
+        ReleaseModifiers = 0x03,
     }
 }

--- a/guest-agent/VfioService/VfioService/StuckKeyFix.cs
+++ b/guest-agent/VfioService/VfioService/StuckKeyFix.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace VfioService
+{
+    public class StuckKeyFix
+    {
+        [DllImport("User32.dll", SetLastError = true)]
+        private static extern int SendInput(int nInputs, [In, Out, MarshalAs(UnmanagedType.LPArray)] Input[] pInputs, int cbSize);
+
+        [DllImport("User32.dll")]
+        private static extern IntPtr GetMessageExtraInfo();
+
+        private enum VirtualKeyCode : ushort
+        {
+            Shift = 0x10,
+            Control = 0x11,
+            Menu = 0x12,
+        }
+
+        private const int INPUT_KEYBOARD = 0x1;
+        private const int KEYEVENTF_KEYUP = 0x2;
+
+        [StructLayout(LayoutKind.Explicit, Size = 28)]
+        private struct Input
+        {
+            [FieldOffset(00)]
+            UInt32 type;
+            [FieldOffset(04)]
+            VirtualKeyCode wVk;
+            [FieldOffset(06)]
+            UInt16 wScan;
+            [FieldOffset(08)]
+            UInt32 dwFlags;
+            [FieldOffset(12)]
+            UInt32 time;
+            [FieldOffset(16)]
+            IntPtr dwExtraInfo;
+
+            public Input(VirtualKeyCode key)
+            {
+                type = INPUT_KEYBOARD;
+                wVk = key;
+                wScan = 0;
+                dwFlags = KEYEVENTF_KEYUP;
+                time = 0;
+                dwExtraInfo = GetMessageExtraInfo();
+            }
+        }
+
+        public static void ReleaseModifiers()
+        {
+            var inputs = new Input[]
+            {
+                new Input(VirtualKeyCode.Shift),
+                new Input(VirtualKeyCode.Control),
+                new Input(VirtualKeyCode.Menu),
+            };
+
+            SendInput(inputs.Length, inputs, Marshal.SizeOf(typeof(Input)));
+        }
+    }
+}

--- a/guest-agent/VfioService/VfioService/VfioService.csproj
+++ b/guest-agent/VfioService/VfioService/VfioService.csproj
@@ -74,6 +74,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="StuckKeyFix.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/windows-gaming-driver/src/controller.rs
+++ b/windows-gaming-driver/src/controller.rs
@@ -58,6 +58,7 @@ enum QmpCommand {
 enum GaCmd {
     Ping = 0x01,
     RegisterHotKey = 0x02,
+    ReleaseModifiers = 0x03,
 }
 
 fn writemon(monitor: &mut UnixStream, command: &QmpCommand) {
@@ -192,6 +193,9 @@ impl Controller {
         if self.io_attached {
             return;
         }
+
+        // might still be holding keyboard modifiers - release them
+        self.write_ga(GaCmd::ReleaseModifiers);
 
         let mut udev = Context::new().expect("Failed to create udev context");
 


### PR DESCRIPTION
TODO: figure out why it doesn't work

StuckKeyFix.ReleaseModifiers() does exactly what you expect it to do whenever
I tested it manually. But calling it on IO exit and entry doesn't work for some reason.